### PR TITLE
Creato uno scheletro di Security

### DIFF
--- a/src/main/java/it/plansoft/BusinessManagement/SecurityConfiguration.java
+++ b/src/main/java/it/plansoft/BusinessManagement/SecurityConfiguration.java
@@ -1,0 +1,45 @@
+package it.plansoft.BusinessManagement;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter{
+	
+	/*
+	@Autowired
+	DataSource dataSource;
+	*/
+	
+	@Override
+	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+		/*
+		auth.jdbcAuthentication()
+		.dataSource(dataSource);
+		*/
+		auth.inMemoryAuthentication()
+		.withUser("user")
+		.password("pass")
+		.roles("USER")
+		.and()
+		.withUser("admin")
+		.password("pass")
+		.roles("ADMIN");
+		
+	}
+	
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.csrf().disable(); //temporaneo
+		//http.authorizeRequests()
+	}
+	
+	public PasswordEncoder getPasswordEncoder() {
+		return NoOpPasswordEncoder.getInstance();
+	}
+}


### PR DESCRIPTION
Closes #7 
Configurato Spring Security per memorizzare due utenti (user e admin),
con password "pass" e disabilitando il controllo csrf per i test